### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#WMIOps
+# WMIOps
 
 WMIOps is a powershell script that uses WMI to perform a variety of actions on hosts, local or remote, within
 a Windows environment.  It's designed primarily for use on penetration tests or red team engagements.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
